### PR TITLE
Use latest base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN go test -v
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"'
 
 # Stage 2: Build official image based on UBI
-FROM registry.access.redhat.com/ubi7-minimal:7.6-123
+FROM registry.access.redhat.com/ubi7-minimal
 
 ARG VERSION
 ARG BUILD_DATE


### PR DESCRIPTION
Remove Dockerfile's reference to a specific tag of the base image.